### PR TITLE
Fix initial loading of character models

### DIFF
--- a/index.html
+++ b/index.html
@@ -788,13 +788,16 @@
                 
                 // Initialize renderer
                 houseRenderer = new HouseRenderer(scene);
-                
+
                 // Make renderer available globally for Person animation registration
                 window.houseRenderer = houseRenderer;
-                
+
                 // Set camera reference and config for culling
                 houseRenderer.setCamera(camera);
                 houseRenderer.setConfig(this.config);
+
+                // Load person models before any rendering occurs
+                await houseRenderer.loadPersonModels();
                 
                 // Initialize enhanced person manager
                 window.peopleDebug('Creating EnhancedPersonManager...');

--- a/lib/js/renderer.js
+++ b/lib/js/renderer.js
@@ -34,10 +34,8 @@ class HouseRenderer {
         // this.animationFrameInterval = 1000 / this.animationFrameRate; // ~33.33ms
         // this.lastAnimationUpdate = 0;
         
-        // Test GLB loading with a simple model first
-        this.testGLBLoading();
-        
-        // Debug animation system
+        // Person models will be loaded explicitly by the simulation
+        // Debug animation system (will show empty model list until loaded)
         this.debugAnimationSystem();
     }
     


### PR DESCRIPTION
## Summary
- load person models during initialization so GLB models are available before people are added
- remove automatic testGLBLoading call from renderer construction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d8db779a08320a58a47266443f950