### PR TITLE
Fix idle animation

### DIFF
--- a/lib/js/person.js
+++ b/lib/js/person.js
@@ -783,28 +783,9 @@ class Person {
         }
     }
     
-    // Update animation state
+    // Update animation state (logic-only, mixer updated in renderer)
     updateAnimation(deltaTime) {
-        if (this.currentTask) {
-            // Action-specific animations
-            const actionAnimations = {
-                'sleeping': 'sleeping',
-                'eating': 'eating',
-                'bathing': 'bathing',
-                'using_bathroom': 'using_bathroom',
-                'watching_tv': 'sitting',
-                'socializing': 'talking',
-                'cleaning': 'cleaning',
-                'exercise': 'exercising',
-                'reading': 'reading'
-            };
-            
-            this.animationState = actionAnimations[this.currentTask.type] || 'idle';
-        }
-        
-        // Update Three.js animation mixer if available
         if (this.animationMixer) {
-            // This will be called from the renderer with proper delta time
             // The actual mixer.update() happens in the renderer
         }
     }
@@ -888,43 +869,11 @@ class Person {
     // Update animation based on current state
     updateAnimationState() {
         let targetAnimation = 'idle';
-        
-        // Check if person is stuck or has no valid path
-        const isStuck = this.isMoving && this.currentPath && this.currentPath.length === 0;
-        const hasNoPath = this.isMoving && !this.currentPath;
-        // Use tick-based timeout check instead of performance.now()
-        const maxTicks = this.movementTimeout * 60; // Convert seconds to ticks (assuming 60 FPS)
-        const isTimeout = this.movementStartTime > 0 && this.movementStartTime > maxTicks;
-        
-        if (this.isMoving && !isStuck && !hasNoPath && !isTimeout) {
+
+        if (this.currentTask || this.isMoving) {
             targetAnimation = 'walking';
-        } else if (this.currentTask) {
-            // Map behavior actions to animation names
-            const actionToAnimation = {
-                'sleeping': 'sleeping',
-                'eating': 'eating',
-                'bathing': 'bathing',
-                'using_bathroom': 'using_bathroom',
-                'watching_tv': 'sitting',
-                'socializing': 'talking',
-                'cleaning': 'cleaning',
-                'exercise': 'exercising',
-                'reading': 'reading'
-            };
-            
-            targetAnimation = actionToAnimation[this.currentTask.type] || 'idle';
-        } else {
-            // Not moving, not doing a task - use idle
-            targetAnimation = 'idle';
         }
-        
-        // Force idle if stuck or has issues
-        if (isStuck || hasNoPath || isTimeout) {
-            targetAnimation = 'idle';
-            window.eventBus.log('DEBUG', `Person ${this.id} forcing idle animation due to movement issues`);
-        }
-        
-        // Only change animation if state actually changed
+
         if (this.animationState !== targetAnimation) {
             this.animationState = targetAnimation;
             this.fadeToAction(targetAnimation, 0.3);


### PR DESCRIPTION
## Summary
- simple animation state machine
- people go idle when they are not moving and have no task

## Testing
- `node -e "global.window={eventBus:{log:()=>{}}}; require('./lib/js/person.js'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_687d8f5a07a88320ae46d1aab783eda8