### PR TITLE
Fix walking animation stuck when idle

### DIFF
--- a/lib/js/person.js
+++ b/lib/js/person.js
@@ -870,7 +870,8 @@ class Person {
     updateAnimationState() {
         let targetAnimation = 'idle';
 
-        if (this.currentTask || this.isMoving) {
+        // Only switch to walking when the person is actively moving
+        if (this.isMoving) {
             targetAnimation = 'walking';
         }
 


### PR DESCRIPTION
## Summary
- stop switching to walking animation when a person has a task but isn't moving

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d926f5c908320b7fd229b054a9346