### PR TITLE
Fix furniture interaction for needs

### DIFF
--- a/lib/js/enhancedPerson.js
+++ b/lib/js/enhancedPerson.js
@@ -27,6 +27,9 @@ class EnhancedPerson extends Person {
         
         // Enhanced personality
         this.personality = this.generatePersonality();
+
+        // Helper for finding accessible interaction points
+        this.furnitureInteraction = new window.FurnitureInteraction();
         
         window.eventBus.log('INFO', `Created enhanced ${type} person ${id}: ${this.displayName}`);
     }
@@ -104,7 +107,7 @@ class EnhancedPerson extends Person {
             const adjustedValue = value * priority;
             
             if (adjustedValue < this.needThresholds.low && this.shouldGenerateTaskForNeed(need)) {
-                const task = this.createTaskForNeed(need, rooms);
+                const task = this.createTaskForNeed(need, rooms, house);
                 if (task) {
                     this.addTaskToQueue(task);
                 }
@@ -126,7 +129,7 @@ class EnhancedPerson extends Person {
     }
     
     // Create a task for a specific need
-    createTaskForNeed(need, rooms) {
+    createTaskForNeed(need, rooms, house) {
         const furnitureInfo = this.findSuitableFurniture(need, rooms);
         if (!furnitureInfo) {
             return this.createWanderTask(need);
@@ -135,6 +138,29 @@ class EnhancedPerson extends Person {
         const actionType = this.getActionTypeForNeed(need, furnitureInfo.furniture.type);
         const duration = this.getActionDuration(actionType);
         
+        // Default target: furniture center
+        let targetX = furnitureInfo.room.worldX +
+            (furnitureInfo.furniture.gridX - furnitureInfo.room.gridX) * this.config.gameSettings.cellSize;
+        let targetZ = furnitureInfo.room.worldZ +
+            (furnitureInfo.furniture.gridZ - furnitureInfo.room.gridZ) * this.config.gameSettings.cellSize;
+
+        // Try to find a reachable interaction zone
+        if (this.furnitureInteraction && house) {
+            const zone = this.furnitureInteraction.getBestInteractionZone(
+                furnitureInfo.furniture,
+                furnitureInfo.room,
+                house,
+                this.gridX,
+                this.gridZ
+            );
+            if (zone) {
+                targetX = furnitureInfo.room.worldX +
+                    (zone.x - furnitureInfo.room.gridX) * this.config.gameSettings.cellSize;
+                targetZ = furnitureInfo.room.worldZ +
+                    (zone.z - furnitureInfo.room.gridZ) * this.config.gameSettings.cellSize;
+            }
+        }
+
         return {
             id: `task_${this.id}_${Date.now()}_${Math.random()}`,
             type: 'use_furniture',
@@ -142,8 +168,8 @@ class EnhancedPerson extends Person {
             actionType: actionType,
             furniture: furnitureInfo.furniture,
             room: furnitureInfo.room,
-            targetX: furnitureInfo.room.worldX + (furnitureInfo.furniture.gridX - furnitureInfo.room.gridX) * this.config.gameSettings.cellSize,
-            targetZ: furnitureInfo.room.worldZ + (furnitureInfo.furniture.gridZ - furnitureInfo.room.gridZ) * this.config.gameSettings.cellSize,
+            targetX,
+            targetZ,
             duration: duration,
             progress: 0,
             priority: this.calculateTaskPriority(need),
@@ -261,13 +287,28 @@ class EnhancedPerson extends Person {
             this.startTask(currentTask, house);
         }
         
-        // Update task progress
+        // Update task progress only when in range
         if (this.currentTask && this.currentTask.id === currentTask.id) {
-            currentTask.progress += deltaTime;
-            
-            // Check if task is complete
-            if (currentTask.progress >= currentTask.duration) {
-                this.completeTask(currentTask);
+            let inRange = true;
+            if (currentTask.type === 'use_furniture') {
+                if (this.furnitureInteraction) {
+                    inRange = this.furnitureInteraction.isInInteractionRange(
+                        this.gridX,
+                        this.gridZ,
+                        currentTask.furniture
+                    );
+                } else {
+                    const dist = this.getDistanceToFurniture(currentTask.furniture, currentTask.room);
+                    inRange = dist <= 1.5;
+                }
+            }
+
+            if (inRange) {
+                currentTask.progress += deltaTime;
+
+                if (currentTask.progress >= currentTask.duration) {
+                    this.completeTask(currentTask);
+                }
             }
         }
     }
@@ -281,6 +322,7 @@ class EnhancedPerson extends Person {
             this.targetX = task.targetX;
             this.targetZ = task.targetZ;
             this.isMoving = true;
+            this.calculatePathToTarget(task.targetX, task.targetZ);
             
             // Mark furniture as in use
             if (task.furniture) {


### PR DESCRIPTION
## Summary
- ensure enhanced people know how to navigate to usable furniture
- choose reachable interaction zones when creating tasks
- only progress task timers when close to the target
- start pathfinding when starting a task

## Testing
- `node --check lib/js/enhancedPerson.js`

------
https://chatgpt.com/codex/tasks/task_e_687d97271bb883209e47132ff16f409c