### PR TITLE
Fix zone logging error in FurnitureInteraction

### DIFF
--- a/lib/js/furnitureInteraction.js
+++ b/lib/js/furnitureInteraction.js
@@ -84,7 +84,7 @@ class FurnitureInteraction {
         const zones = this.getInteractionZones(furniture, room);
         const accessibleZones = [];
         
-        window.eventBus.log('DEBUG', `Checking accessibility from person (${personX}, ${personZ}) to zone (${gridX}, ${gridZ})`);
+        // Iterate over each potential zone and log accessibility checks
         
         for (const zone of zones) {
             if (this.isZoneAccessible(zone, furniture, room, house)) {
@@ -92,10 +92,12 @@ class FurnitureInteraction {
                 if (this.canPersonReachZone(personX, personZ, zone.x, zone.z, house)) {
                     zone.accessible = true;
                     accessibleZones.push(zone);
-                    window.eventBus.log('DEBUG', `Found accessible interaction zone for ${furniture.type} at (${gridX}, ${gridZ})`);
+                    window.eventBus.log('DEBUG', `Found accessible interaction zone for ${furniture.type} at (${zone.x}, ${zone.z})`);
                 } else {
-                    window.eventBus.log('DEBUG', `Zone (${gridX}, ${gridZ}) is not accessible from person position (${personX}, ${personZ})`);
+                    window.eventBus.log('DEBUG', `Zone (${zone.x}, ${zone.z}) is not accessible from person position (${personX}, ${personZ})`);
                 }
+            } else {
+                window.eventBus.log('DEBUG', `Zone (${zone.x}, ${zone.z}) failed initial accessibility checks`);
             }
         }
         


### PR DESCRIPTION
## Summary
- correct undefined `gridX`/`gridZ` references when searching for furniture interaction zones
- add extra debug logging when zone accessibility fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e1484ef888320bb5aadc1690083ea